### PR TITLE
Mostrar mensaje de error en caso de que falle la consulta a la API - OT286-42

### DIFF
--- a/app/src/main/java/com/melvin/ongandroid/viewmodel/OngViewModel.kt
+++ b/app/src/main/java/com/melvin/ongandroid/viewmodel/OngViewModel.kt
@@ -64,7 +64,7 @@ class OngViewModel(private val repositoryWelcomeImages : IWelcomeDataRepository,
                 FirebaseLog.logSliderSuccess()
                 if(list.isNullOrEmpty()){
                     _listaSlide.value = emptyList()
-                    _error.value = true
+                    
                 }else{
                     _listaSlide.value = list
                 }
@@ -93,7 +93,7 @@ class OngViewModel(private val repositoryWelcomeImages : IWelcomeDataRepository,
                 FirebaseLog.logNovedadesSuccess()
                 if(list.isNullOrEmpty()){
                     _listaNovedad.value = emptyList()
-                    _error.value = true
+
                 }else{
                     _listaNovedad.value = list
                 }
@@ -120,7 +120,7 @@ class OngViewModel(private val repositoryWelcomeImages : IWelcomeDataRepository,
                 FirebaseLog.logTestimonioSuccess()
                 if(list.isNullOrEmpty()){
                     _listaTestimonios.value = emptyList()
-                    _error.value = true
+
                 }else{
                 _listaTestimonios.value = list 
                 }


### PR DESCRIPTION
Mando el ticket porque me correspondia, pero la verdad es que cuando lo quise hacer ya estaba hecho, por error un compañero hizo las excepciones que quedaban y a la vez generalizo el error que se muestra por pantalla. Lo cual le da una estructura mas ordenada al proyecto, pero con la consecuencia de que me quede con poco que hacer para este ticket. De todas formas ya lo hablamos en slack. Mi contribucion es que en caso de que venga algo en null se setee una lista vacia.