### PR TITLE
Validar los campos antes de realizar una consulta - 60

### DIFF
--- a/app/src/test/java/com/melvin/ongandroid/viewmodel/OngViewModelTest.kt
+++ b/app/src/test/java/com/melvin/ongandroid/viewmodel/OngViewModelTest.kt
@@ -117,7 +117,7 @@ class OngViewModelTest{
     @Test
     fun `when getNovedades return a list of images set on the LiveData`() = runTest{
         //Given
-        val list = listOf(Novedad("example.png", "Imagen 1", "Descripcion 1"))
+        val list = listOf(Novedad("example.png", "Imagen 1", "Descripcion 1", 1))
         coEvery {repositoryNovedad.getNovedades()} returns list
 
         //When


### PR DESCRIPTION
Me parece que me equivoque Leandro, por error se mandaron los dos tickets juntos no se porque. Es raro porque ayer hice el de crear la vista de contacto y te lo mande. Hoy actualice mi fork con este ticket y por alguna razon se actualizo tambien el pr que mande ayer, integrandolo todo junto. Hice una pequeña modificacion para justificar el commit pero la validacion se mando en el anterior ticket que mande. Adjunto captura.

Deshabilitado:
![WhatsApp Image 2022-09-01 at 2 09 14 PM](https://user-images.githubusercontent.com/50328224/188017440-54aaf2de-7c89-4d5d-bb5d-e9e32537e2db.jpeg)

Habilitado:
![WhatsApp Image 2022-09-01 at 2 09 14 PM (1)](https://user-images.githubusercontent.com/50328224/188017477-0df8892d-c57b-4ba7-b03f-0aaeb1171915.jpeg)
